### PR TITLE
deprecation warnings & sinatra-flash

### DIFF
--- a/lib/padrino/warden.rb
+++ b/lib/padrino/warden.rb
@@ -90,7 +90,7 @@ module Padrino
         post :unauthenticated, :map => '/unauthenticated'  do
           status 401
           warden.custom_failure! if warden.config.failure_app == self.class
-          flash[:error] = settings.auth_error_message if flash
+          flash.now[:error] = settings.auth_error_message if flash
           render settings.auth_login_template
         end
 


### PR DESCRIPTION
- dont depend on Rack::Flash as there is now Sinatra:Flash
- use settings instead of options, sinatra deprecation warnings
