### PR TITLE
Make sure modified request isn't stopped by Rack::Protection::AuthenticityToken

### DIFF
--- a/lib/padrino-warden.rb
+++ b/lib/padrino-warden.rb
@@ -7,4 +7,9 @@ Warden::Manager.before_failure do |env, opts|
   # to set it for the failure app so it is routed to the correct block
   env['REQUEST_METHOD'] = "POST"
 
+  # Make sure our modified request isn't stopped by
+  # Rack::Protection::AuthenticityToken, if user doesn't have csrf set yet
+  request = Rack::Request.new(env)
+  csrf = request.session[:csrf] || SecureRandom.hex(32)
+  env['HTTP_X_CSRF_TOKEN'] = request.session[:csrf] = csrf
 end


### PR DESCRIPTION
If user doesn't have csrf set yet, then Rack::Protection::AuthenticityToken will happily stop post request

This problem will occur in edge padrino, if csrf protection is enabled.
