### PR TITLE
Don't clobber a truthy :sessions value

### DIFF
--- a/lib/padrino/warden/helpers.rb
+++ b/lib/padrino/warden/helpers.rb
@@ -55,7 +55,7 @@ module Padrino
         app.helpers Helpers
 
         # Enable Sessions
-        app.set :sessions, true
+        app.set :sessions, true unless app.sessions
         app.set :auth_failure_path, '/'
         app.set :auth_success_path, '/'
         # Setting this to true will store last request URL


### PR DESCRIPTION
This fork fixes a misbehavior in the registration of the Padrino::Warden module.  If the Padrino app has already configured the :sessions setting, the Padrino::Warden's #registered helper will overwrite the :sessions configuration with 'true'.  The code change in this fork prevents the overwriting if the :sessions value is already truthy.
