### PR TITLE
Callback before_logout not called when logging out

### DIFF
--- a/lib/padrino/warden/helpers.rb
+++ b/lib/padrino/warden/helpers.rb
@@ -29,6 +29,7 @@ module Padrino
       #
       # @param [Symbol] the session scope to terminate
       def logout(scopes=nil)
+        authenticated?
         scopes ? warden.logout(scopes) : warden.logout
       end
 


### PR DESCRIPTION
Hi,

I'm working on a SaaS Application using *Padrino*, *Apartment* for multitenant and *padrino-warden* for authentication.  I implemented two strategies (:token and :password) and when I need to delete my remember_token, the  **before_logout** callback  isn't called. 

I read about it and I found this issue in Warden https://github.com/hassox/warden/issues/76: Warden::Proxy.set_user isn't called before logout, then there is no **@user** to invoke their callbacks. 

A solution is to call **env['warden'].authenticated?** before closing the session, but when I use padrino-warden I have no chance of this.  Then I added a call to **autenticated?** in **logout** method of Helper, and voila, before_logout called again.
