### PR TITLE
Re-Allow to register helpers without controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ After login you can fiddle with *current\_user* for anything you need.
 
 ## Multi Sub-Apps
 
-You UserApp(/user):
+padrino-warden can be used across multiple apps in one project. You need to have one UserApp which handles logins and logouts.
+
+Add this to your UserApp(/user):
 
 ```ruby
 register Padrino::Warden
@@ -74,7 +76,17 @@ You OtherApps:
 register Padrino::Warden::Helpers
 ```
 
-But you must apply the same options in your UserApp.
+Configure warden globally within config/apps.rb. Don't forget to tell warden about the UserApp:
+
+```ruby
+Padrino.configure_apps do
+  ...
+  set :warden_failure_app, UserApp
+end
+```
+
+Your UserApp needs to be mounted first in Padrino! Cascading routes from the UserApp can cause exceptions, so don't use an app mounted to the root path ('/') as UserApp.
+
 
 ## Overriding warden manager defaults
 
@@ -99,7 +111,7 @@ end
 ```
 
 ## Note on Patches/Pull Requests
- 
+
 * Fork the project.
 * Make your feature addition or bug fix.
 * Add tests for it. This is important so I don't break it in a

--- a/lib/padrino/warden.rb
+++ b/lib/padrino/warden.rb
@@ -31,7 +31,7 @@ module Padrino
       app.set :auth_use_oauth, false
       app.set :default_strategies, [:password] unless app.respond_to?(:default_strategies)
 
-      app.set :warden_failure_app, app
+      app.set :warden_failure_app, app unless app.respond_to?(:warden_failure_app)
       app.set :warden_default_scope, :session
       app.set(:warden_config) { |manager| nil }
       app.use ::Warden::Manager do |manager|

--- a/lib/padrino/warden.rb
+++ b/lib/padrino/warden.rb
@@ -8,7 +8,7 @@ require 'padrino/warden/helpers'
 
 module Padrino
   module Warden
-    def self.registered(app)
+    def self.registered(app, register_controller = true)
       # Enable Sessions
       app.set :sessions, true unless app.sessions
       app.set :auth_failure_path, '/'
@@ -41,7 +41,9 @@ module Padrino
         app.warden_config manager
       end
 
-      Controller.registered app
+      if register_controller
+        Controller.registered app
+      end
       app.helpers Helpers
     end
   end

--- a/lib/padrino/warden/controller.rb
+++ b/lib/padrino/warden/controller.rb
@@ -25,7 +25,7 @@ module Padrino
           post :login , map: app.auth_login_path do
             authenticate
             flash[:success] = settings.auth_success_message if flash
-            redirect settings.auth_use_referrer && session[:return_to] ? session.delete(:return_to) : 
+            redirect settings.auth_use_referrer && session[:return_to] ? session.delete(:return_to) :
               settings.auth_success_path
           end
 

--- a/lib/padrino/warden/helpers.rb
+++ b/lib/padrino/warden/helpers.rb
@@ -51,6 +51,11 @@ module Padrino
         warden.set_user(new_user, opts)
       end
       alias_method :current_user=, :user=
+
+      # Register the helpers directly without the controller (useful for MultiApp environments)
+      def self.registered(app)
+        Padrino::Warden.registered(app, false)
+      end
     end # helpers
   end # Warden
 end # Padrino


### PR DESCRIPTION
Example from the README:

You OtherApps:
```ruby
register Padrino::Warden::Helpers
```

This is broken in current Versions of Padrino. 

This PR readds this functionality while maintaining compatibility