### PR TITLE
bugfix: 'authenticate'(/'login') should work with auth_use_referrer

### DIFF
--- a/lib/padrino/warden.rb
+++ b/lib/padrino/warden.rb
@@ -14,10 +14,10 @@ module Padrino
       app.set :auth_failure_path, '/'
       app.set :auth_success_path, '/'
 
-      # Setting this to true will store last request URL
-      # into a user's session so that to redirect back to it
-      # upon successful authentication
+      # set :auth_use_referrer to true to redirect a user back to an action
+      # protected by 'login'/'authenticate' after successful login
       app.set :auth_use_referrer,      false
+
       app.set :auth_error_message,     "You have provided invalid credentials."
       app.set :auth_success_message,   "You have logged in successfully."
       app.set :deauth_success_message, "You have logged out successfully."

--- a/lib/padrino/warden/controller.rb
+++ b/lib/padrino/warden/controller.rb
@@ -13,6 +13,7 @@ module Padrino
           end
           ## /sessions/login
           get :login , map: app.auth_login_path  do
+            session.delete(:return_to)
             if settings.auth_use_oauth && !@auth_oauth_request_token.nil?
               session[:request_token] = @auth_oauth_request_token.token
               session[:request_token_secret] = @auth_oauth_request_token.secret

--- a/lib/padrino/warden/helpers.rb
+++ b/lib/padrino/warden/helpers.rb
@@ -21,6 +21,8 @@ module Padrino
 
       # Authenticate a user against defined strategies
       def authenticate(*args)
+        session[:return_to] = request.fullpath if settings.auth_use_referrer and
+          env['REQUEST_METHOD'] == 'GET'
         warden.authenticate!(*args)
       end
       alias_method :login, :authenticate


### PR DESCRIPTION
`authenticate`/`login` doesn't currently respect the `auth_use_referrer` setting now. With this patch, things become a little bit more automatic, instead of having to manually set things up.

```
get :blah do
    if !current_user
        session[:return_to] = url(CONTROLLER, :blah)
        redirect url(:sessions, :login)
    end
    ...
end
```